### PR TITLE
config: removed one global variable, improved the code and added tests

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 type Config struct {
@@ -11,16 +11,16 @@ type Config struct {
 	Servers map[string]string `json:"servers"`
 }
 
-func readConfig(config *Config, path string) error {
-	data, err := ioutil.ReadFile(path)
+var config Config
+
+func readConfig(path string) error {
+	file, err := os.Open(path)
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 
-	err = json.Unmarshal(data, config)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	dec := json.NewDecoder(file)
+	err = dec.Decode(&config)
+	return err
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+func TestFailReadConfig(t *testing.T) {
+	err := readConfig("does-not-exist.json")
+	if err == nil ||
+		err.Error() != "open does-not-exist.json: no such file or directory" {
+
+		t.Fatalf("It should've failed because the file does not exist.")
+	}
+}
+
+func TestReadConfig(t *testing.T) {
+	err := readConfig("obs2vagrant.json.example")
+	if err != nil {
+		t.Fatalf("It should be ok")
+	}
+
+	if config.Address != "127.0.0.1" {
+		t.Fatalf("Wrong address")
+	}
+	if config.Port != 8080 {
+		t.Fatalf("Wrong port")
+	}
+	if len(config.Servers) != 2 {
+		t.Fatalf("Wrong numbers of servers")
+	}
+	if config.Servers["obs"] != "http://download.opensuse.org/repositories/" {
+		t.Fatalf("Wrong config for obs")
+	}
+	if config.Servers["ibs"] != "http://download.suse.de/ibs/" {
+		t.Fatalf("Wrong config for ibs")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,27 +2,21 @@ package main
 
 import (
 	"flag"
-	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/justinas/alice"
 )
 
-var config *Config
-var configFile string
-
-func init() {
-	const (
-		defaultConfigFile = "obs2vagrant.json"
-	)
-	flag.StringVar(&configFile, "c", defaultConfigFile, "configuration file")
-}
-
 func main() {
+	var configFile string
+	const defaultConfigFile = "obs2vagrant.json"
+	flag.StringVar(&configFile, "c", defaultConfigFile, "configuration file")
 	flag.Parse()
-	config = new(Config)
-	err := readConfig(config, configFile)
+
+	err := readConfig(configFile)
 	if err != nil {
 		log.Fatalf("Error while parsing configuration file: %s", err)
 	}


### PR DESCRIPTION
The `configFile` variable can be a local in the main function. Moreover, the
reading of the config can be done with a decoder, instead of reading the file
and then parse it. Finally, I've added tests for the configuration part.
